### PR TITLE
1.0.203 fix for user already exists in org

### DIFF
--- a/api/src/controllers/organizations.js
+++ b/api/src/controllers/organizations.js
@@ -1,11 +1,12 @@
 import log from 'log'
 import { AUDIT_ACTIONS, RULES } from '../constants'
 import { createAudit } from '../utils/audit'
-import { getInstallations } from '../utils/init'
+import { getAuthenticatedApps, getInstallations } from '../utils/init'
 import { hasRule } from '../utils/roles'
 
 export const organizations = async (req, res) => {
   // gets available orgs to make requests too
+
   if (!hasRule(req.auth.role, RULES.organizations)) {
     log.warn(
       `user ${req.auth.user} does not have sufficient priviledge for ${AUDIT_ACTIONS.api.organizations.list}`
@@ -27,10 +28,20 @@ export const organizations = async (req, res) => {
     })
     return
   }
+
+  const authenticatedApps = await getAuthenticatedApps()
+  const appIds = Object.keys(authenticatedApps.apps).map(
+    (app) => authenticatedApps.apps[app].id
+  )
+
   const installations = await getInstallations()
+  // only return installstions that have been configured in the app
+  const configuredInstallations = installations.filter(
+    (installation) => appIds.findIndex((id) => id === installation.id) > -1
+  )
 
   res.json(
-    installations.map((installation) => ({
+    configuredInstallations.map((installation) => ({
       id: installation.account.id,
       name: installation.account.login,
       image: installation.account.avatar_url,

--- a/api/src/utils/github.js
+++ b/api/src/utils/github.js
@@ -1,18 +1,57 @@
 import log from 'log'
+import { INVITATION_REQUEST_STATES } from '../constants'
+import InvitationRequest from '../db/models/InvitationRequest'
 import { getConfig } from './config'
 import { getAuthenticatedApps } from './init'
 
-export const inviteUserToOrgs = async (userId, orgs) => {
-  log.debug(`inviteUserToOrg ${userId} ${orgs}`)
+export const inviteUserToOrg = async (userId, org) => {
   const installations = await getAuthenticatedApps()
-  const promises = orgs.map((org) => {
-    const app = installations.apps[org.toLowerCase()]
-    return app.authenticatedRequest('POST /orgs/{org}/invitations', {
-      org,
-      invitee_id: userId,
-    })
+  const app = installations.apps[org.toLowerCase()]
+  return app.authenticatedRequest('POST /orgs/{org}/invitations', {
+    org,
+    invitee_id: userId,
   })
-  await Promise.all(promises)
+}
+
+export const inviteUserToOrgs = async (userId, orgs, recipient, requester) => {
+  log.debug(`inviteUserToOrg ${userId} ${orgs}`)
+
+  return orgs.map(async (org) => {
+    try {
+      log.info(`User ${userId} is being invited to ${org}`)
+      await inviteUserToOrg(userId, org)
+      log.info(`User ${userId} is to ${org}`)
+      await InvitationRequest.create({
+        organization: org.toLowerCase(),
+        recipient,
+        requester,
+        apiVersion: 'v1',
+        state: INVITATION_REQUEST_STATES.APPROVED,
+      })
+    } catch (e) {
+      if (e.status === 422) {
+        log.info(`User ${userId} is already in org ${org}. Skipping.`)
+        await InvitationRequest.create({
+          organization: org.toLowerCase(),
+          recipient,
+          requester,
+          apiVersion: 'v1',
+          state: INVITATION_REQUEST_STATES.APPROVED,
+        })
+      } else {
+        log.error(`Could not invite ${userId} to org ${org}`)
+        log.debug(JSON.stringify(e))
+        await InvitationRequest.create({
+          organization: org.toLowerCase(),
+          recipient,
+          requester,
+          apiVersion: 'v1',
+          state: INVITATION_REQUEST_STATES.FAILED,
+        })
+        throw e
+      }
+    }
+  })
 }
 
 export const getUserByName = async (username) => {


### PR DESCRIPTION
If a user already existed in an org and yu tried to invite them the entire request would fail. This has been fixed by independently making each request and catching the 422 status code.