### PR TITLE
Allow just ask api to be config'd with multiple origins 

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -7,3 +7,4 @@ dist
 **/**/role-mappers.json
 src/config/config.json
 src/config/role-mappers.json
+src/config/cors.json

--- a/api/README.md
+++ b/api/README.md
@@ -60,6 +60,9 @@ Apply these configurations to your container runtime
       mountPath: /var/opt/config/github-private-key.pem
     - name: config.json
       mountPath: /var/opt/config/config.json
+    - name: cors.json
+      mountPath: /var/opt/config/cors.json
+
 ```
 #### Examples
 1. Docker
@@ -123,6 +126,8 @@ stringData:
     }
   config.json: |
     similar
+  cors.json: |
+    [ "https://youroriginstoyourwebcomponent.com" ]
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/api/src/config/cors.example.json
+++ b/api/src/config/cors.example.json
@@ -1,0 +1,1 @@
+[ "https://google.com", "https://developer.gov.bc.ca" ]

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -13,6 +13,16 @@ import requestRouters from './routes/requests'
 import statRouters from './routes/stats'
 import auditRouters from './routes/audits'
 import { getUserFromToken, logMiddleware } from './middlewares/index.js'
+import { getCorsPolicy } from './utils/cors.js'
+
+const handleCors = (origin, callback) => {
+  const allowList = getCorsPolicy()
+  if (allowList.indexOf(origin) !== -1) {
+    callback(null, true)
+  } else {
+    callback(new Error('Not allowed by CORS'))
+  }
+}
 
 async function initailize() {
   logNode()
@@ -38,7 +48,7 @@ async function initailize() {
 
   log.notice(`Cors enabled for ${process.env.WEB_URL}`)
 
-  app.use(cors({ origin: process.env.WEB_URL }))
+  app.use(cors({ origin: handleCors }))
   app.use(logMiddleware)
 
   app.get('/server-health', (req, res) =>

--- a/api/src/tests/cors.test.js
+++ b/api/src/tests/cors.test.js
@@ -1,0 +1,66 @@
+import { getCorsPolicy } from '../utils/cors'
+import { getCors } from '../utils/config'
+
+jest.mock('../utils/config')
+
+describe('Cors Utilities', () => {
+  describe('getCorsPolicy', () => {
+    it('fetches [] when WEB_URL env var is not available or null', () => {
+      const corsUrls = getCorsPolicy(undefined)
+      expect(corsUrls).toEqual([])
+
+      const corsUrls2 = getCorsPolicy(null)
+      expect(corsUrls2).toEqual([])
+    })
+
+    it('fetches the cors WEB_URL env var when available', () => {
+      const webUrl = 'https://AlexisAwesome.com'
+      const corsUrls = getCorsPolicy(webUrl)
+      expect(corsUrls).toEqual(['https://AlexisAwesome.com'])
+
+      const webUrl2 = 'https://BillyisAwesome.com'
+      const corsUrls2 = getCorsPolicy(webUrl2)
+      expect(corsUrls2).toEqual(['https://BillyisAwesome.com'])
+    })
+
+    it('fetches urls from cors.json', () => {
+      const corsConfig = [
+        'https://PatrickIsAwesome.com',
+        'https://JustAskIsAwesome.com',
+      ]
+      getCors.mockReturnValueOnce(corsConfig)
+
+      const corsUrls = getCorsPolicy()
+
+      expect(corsUrls).toEqual(corsConfig)
+    })
+    it('combines results if cors.json returns and there is a webUrl', () => {
+      const corsConfig = [
+        'https://PatrickIsAwesome.com',
+        'https://JustAskIsAwesome.com',
+      ]
+      const webUrl = 'https://foo.com'
+      getCors.mockReturnValueOnce(corsConfig)
+
+      const corsUrls = getCorsPolicy(webUrl)
+
+      expect(corsUrls).toEqual([webUrl, ...corsConfig])
+    })
+
+    it('returns [] when fetching cors.json throws (when it does not exist) and webUrl is not defined', () => {
+      getCors.mockImplementation(() => {
+        throw new Error('JSON FILE NOT FOUND')
+      })
+      const corsUrls = getCorsPolicy()
+      expect(corsUrls).toEqual([])
+    })
+
+    it('returns [https://foo.com] when fetching cors.json throws (when it does not exist) and webUrl is https://foo.com', () => {
+      getCors.mockImplementation(() => {
+        throw new Error('JSON FILE NOT FOUND')
+      })
+      const corsUrls = getCorsPolicy('https://foo.com')
+      expect(corsUrls).toEqual(['https://foo.com'])
+    })
+  })
+})

--- a/api/src/utils/config.js
+++ b/api/src/utils/config.js
@@ -40,3 +40,10 @@ export const getGithubPrivateKey = () => {
   const data = readFileSync(getBasePathWithFile('github-private-key.pem'))
   return data.toString()
 }
+
+/** @returns cors policy */
+export const getCors = () => {
+  console.log('SHOULD NOT BE CALLED')
+  const data = readFileSync(getBasePathWithFile('cors.json'))
+  return data.toString()
+}

--- a/api/src/utils/cors.js
+++ b/api/src/utils/cors.js
@@ -1,0 +1,47 @@
+import log from 'log'
+import { getCors } from './config'
+
+/**
+ * checks if verify cors urls
+ * @param {[]string} urls urls from env var or config
+ * @returns {Boolean}
+ */
+export const verifyCorsUrls = (urls) =>
+  urls.every((url) => /https?:\/\//.test(url))
+
+/**
+ * gets cors policy from config
+ * @param {string} webUrl
+ * @returns {[]string}
+ */
+export const getCorsPolicy = (webUrl = undefined) => {
+  let corsUrls = []
+  let corsFromConfig
+  try {
+    corsFromConfig = getCors()
+  } catch (e) {
+    log.info('no cors.json file found')
+    corsFromConfig = null
+  }
+
+  if (webUrl && webUrl !== null) {
+    if (verifyCorsUrls([webUrl])) {
+      corsUrls.push(webUrl)
+    } else {
+      log.warn(
+        `Attempted to configure cors with WEB_URL ${webUrl} but it was invalid and failed the regex "https?://"`
+      )
+    }
+  }
+  // verify cors urls are valid
+  if (corsFromConfig && !verifyCorsUrls(corsFromConfig)) {
+    log.warn(
+      `Attempted to configure cors from config cors.json ${corsFromConfig} but it was invalid and failed the regex "https?://"`
+    )
+  }
+
+  if (corsFromConfig) {
+    corsUrls = corsUrls.concat(corsFromConfig)
+  }
+  return corsUrls
+}

--- a/api/src/utils/init.js
+++ b/api/src/utils/init.js
@@ -3,6 +3,7 @@ import { request } from '@octokit/request'
 import { every, intersectionBy, isArray, isObject, isString } from 'lodash'
 import { getConfig, getGithubPrivateKey } from './config'
 import log from 'log'
+import { getRequestStatuses } from './github'
 
 // cached value
 const installationApps = {
@@ -150,6 +151,7 @@ export const getAuthenticatedApps = async () => {
 export const init = async () => {
   log.info('Checking Authenticated Apps')
   await getAuthenticatedApps()
+  await getRequestStatuses()
 }
 
 export default init

--- a/api/src/utils/init.js
+++ b/api/src/utils/init.js
@@ -3,7 +3,6 @@ import { request } from '@octokit/request'
 import { every, intersectionBy, isArray, isObject, isString } from 'lodash'
 import { getConfig, getGithubPrivateKey } from './config'
 import log from 'log'
-import { getRequestStatuses } from './github'
 
 // cached value
 const installationApps = {
@@ -151,7 +150,6 @@ export const getAuthenticatedApps = async () => {
 export const init = async () => {
   log.info('Checking Authenticated Apps')
   await getAuthenticatedApps()
-  await getRequestStatuses()
 }
 
 export default init

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -25,7 +25,7 @@ The server expects three files:
 1. config.json
 2. role-mappers.json
 3. github-private-key.pem
-
+4. cors.json
 
 `config.json` is a backend descriptor of what installtions this app should expect. Since this application can theoretically be installed anywhere. The server utilizes this file to ensure that only valid changes can be made to the orgs that are configuired from this file.
 
@@ -74,7 +74,13 @@ Role mappings can be created from specific org roles in an org or membership in 
 }
 ```
 
+`cors.json` This config file __is not required__ but will allow you to reach the api from multiple origins. In the case __you have configured `WEB_URL` and `cors.json`__, the cors policy will allow both sets of urls. 
 **Take note of the `null`** field. This is a SPECIAL CASE for `REQUESTER`. If the `index 0` position of `REQUESTER` is `null`. Than any github user is granted that role implicitly. 
+
+```json
+[ "https://www.just-ask.com", "https://just-ask.com" ]
+```
+
 
 The app also takes several environment variables:
 
@@ -85,9 +91,9 @@ The app also takes several environment variables:
 5. `LOG_TIME`: defaults to `null` but can be set to `rel` or `abs`. For production installations `abs` is recommended
 6. `PORT`: defaults to 3000 when `null`.
 7. `MONGO_URL`: __required__ the fully qualified mongo connection string to your mongo database
-8. `WEB_URL`: __required__ to enable cors, the frontend components' origin of Just-ask! needs to be set
+8. `WEB_URL`: __required__ to enable cors, the frontend components' origin of Just-ask! needs to be set eg `WEB_URL=https://just-ask-frontend.com`
 9. `CONFIG_PATH`: __production only__ allows you to change the path of where the api should look for its config files. Only works if `NODE_ENV=production`
-10. PRIVATE_KEY_PATH: __production only__ allows you to change the path of where the private key is located. This is important in k8s based deployments as typically the API config and the private key would be in a configmap and secret respectively.  Only useable when `NODE_ENV=production`
+10. `PRIVATE_KEY_PATH`: __production only__ allows you to change the path of where the private key is located. This is important in k8s based deployments as typically the API config and the private key would be in a configmap and secret respectively.  Only useable when `NODE_ENV=production`
 
 
 ## Web Configuration

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -11,14 +11,17 @@ root * /opt/app-root/www
 # Because we should
 encode zstd gzip
 
-handle /config/* {
-        try_files {path}            
+handle /static/* {
+        header Cache-Control "max-age=31536000"
 }
 
 handle {
-        try_files {path} /
+       header Cache-Control "no-cache, must-revalidate"
 }
 
+handle /service-worker.js {
+        header Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+}
 
 header /service-worker.js {
         # all static assets SHOULD be cached


### PR DESCRIPTION
## Summary

The cors policy was only allowing a single origin. This is a problem if you have multiple origins that you want to hit the api from. For example `justask.com` and `www.justask.com`

created `cors.js` and added tests